### PR TITLE
feat: add support for globs in add mode

### DIFF
--- a/packages/jszip-cli/package.json
+++ b/packages/jszip-cli/package.json
@@ -7,6 +7,7 @@
     "commander": "10.0.0",
     "cosmiconfig": "8.1.0",
     "fs-extra": "11.1.0",
+    "glob": "9.3.2",
     "jszip": "3.10.1",
     "logdown": "3.3.1",
     "progress": "2.0.3"

--- a/packages/jszip-cli/src/BuildService.ts
+++ b/packages/jszip-cli/src/BuildService.ts
@@ -1,8 +1,8 @@
-import * as fs from 'fs-extra';
-import * as JSZip from 'jszip';
-import * as logdown from 'logdown';
-import * as path from 'path';
-import * as progress from 'progress';
+import fs from 'fs-extra';
+import JSZip from 'jszip';
+import logdown from 'logdown';
+import path from 'path';
+import progress from 'progress';
 import {FileService} from './FileService';
 import {Entry, TerminalOptions} from './interfaces';
 

--- a/packages/jszip-cli/src/ExtractService.ts
+++ b/packages/jszip-cli/src/ExtractService.ts
@@ -1,9 +1,9 @@
-import * as fs from 'fs-extra';
-import * as JSZip from 'jszip';
-import * as logdown from 'logdown';
-import * as os from 'os';
-import * as path from 'path';
-import * as progress from 'progress';
+import fs from 'fs-extra';
+import JSZip from 'jszip';
+import logdown from 'logdown';
+import os from 'os';
+import path from 'path';
+import progress from 'progress';
 import {TerminalOptions} from './interfaces';
 
 export class ExtractService {

--- a/packages/jszip-cli/src/FileService.ts
+++ b/packages/jszip-cli/src/FileService.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs-extra';
-import * as logdown from 'logdown';
-import * as path from 'path';
+import fs from 'fs-extra';
+import logdown from 'logdown';
+import path from 'path';
 import type {TerminalOptions} from './interfaces';
 
 export class FileService {

--- a/packages/jszip-cli/src/JSZipCLI.ts
+++ b/packages/jszip-cli/src/JSZipCLI.ts
@@ -1,6 +1,6 @@
 import {cosmiconfigSync} from 'cosmiconfig';
 import type {CosmiconfigResult} from 'cosmiconfig/dist/types';
-import * as logdown from 'logdown';
+import logdown from 'logdown';
 
 import {BuildService} from './BuildService';
 import {ExtractService} from './ExtractService';

--- a/packages/jszip-cli/src/JSZipCLI.ts
+++ b/packages/jszip-cli/src/JSZipCLI.ts
@@ -1,5 +1,6 @@
 import {cosmiconfigSync} from 'cosmiconfig';
 import type {CosmiconfigResult} from 'cosmiconfig/dist/types';
+import {globSync} from 'glob';
 import logdown from 'logdown';
 
 import {BuildService} from './BuildService';
@@ -54,7 +55,7 @@ export class JSZipCLI {
   public add(rawEntries?: string[]): BuildService {
     if (!rawEntries || !rawEntries.length) {
       if (this.options.entries) {
-        rawEntries = this.options.entries;
+        rawEntries = globSync(this.options.entries);
       } else {
         throw new Error('No entries to add.');
       }

--- a/packages/jszip-cli/tsconfig.json
+++ b/packages/jszip-cli/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3438,6 +3438,16 @@ glob@7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@9.3.2:
+  version "9.3.2"
+  resolved "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz#8528522e003819e63d11c979b30896e0eaf52eda"
+  integrity sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^7.4.1"
+    minipass "^4.2.4"
+    path-scurry "^1.6.1"
+
 glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"


### PR DESCRIPTION
This PR adds support for globs in add mode. In order to build successfully with the added `glob` dependency, a slight modification to `tsconfig.json` and all wildcard imports has been made.

I'm happy to add tests, if this PR is of interest.