### PR TITLE
fix: cannot match * on windows

### DIFF
--- a/packages/auto-approver/package.json
+++ b/packages/auto-approver/package.json
@@ -40,7 +40,7 @@
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
     "start": "ts-node src/cli.ts",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "1.10.1"
 }

--- a/packages/double-linked-list/package.json
+++ b/packages/double-linked-list/package.json
@@ -27,7 +27,7 @@
     "dist": "yarn clean && yarn build",
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "3.2.1"
 }

--- a/packages/electron-info/package.json
+++ b/packages/electron-info/package.json
@@ -60,7 +60,7 @@
     "generate:packagejson": "../../bin/generate-hybrid-package-json.sh",
     "postversion": "exit 0",
     "start": "ts-node-esm src/cli.ts -d",
-    "test": "ts-node-esm -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node-esm -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "type": "module",
   "version": "1.19.1"

--- a/packages/exposure-keys/package.json
+++ b/packages/exposure-keys/package.json
@@ -47,7 +47,7 @@
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
     "start": "ts-node src/cli.ts",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "1.5.1"
 }

--- a/packages/gh-open/package.json
+++ b/packages/gh-open/package.json
@@ -51,7 +51,7 @@
     "generate:packagejson": "../../bin/generate-hybrid-package-json.sh",
     "postversion": "exit 0",
     "start": "ts-node-esm src/cli.ts -d",
-    "test": "ts-node-esm -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node-esm -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "type": "module",
   "version": "3.3.1"

--- a/packages/https-proxy/package.json
+++ b/packages/https-proxy/package.json
@@ -41,7 +41,7 @@
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
     "start": "ts-node src/cli.ts",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "1.7.1"
 }

--- a/packages/jszip-cli/package.json
+++ b/packages/jszip-cli/package.json
@@ -9,7 +9,8 @@
     "fs-extra": "11.1.1",
     "jszip": "3.10.1",
     "logdown": "3.3.1",
-    "progress": "2.0.3"
+    "progress": "2.0.3",
+    "glob": "10.0.0"
   },
   "description": "A zip CLI based on jszip.",
   "devDependencies": {
@@ -46,7 +47,7 @@
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
     "start": "cross-env NODE_DEBUG=\"jszip-cli/*\" ts-node src/cli.ts",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "3.3.1"
 }

--- a/packages/jszip-cli/package.json
+++ b/packages/jszip-cli/package.json
@@ -10,7 +10,7 @@
     "jszip": "3.10.1",
     "logdown": "3.3.1",
     "progress": "2.0.3",
-    "glob": "10.0.0"
+    "glob": "10.2.1"
   },
   "description": "A zip CLI based on jszip.",
   "devDependencies": {

--- a/packages/jszip-cli/spec/BuildService.test.ts
+++ b/packages/jszip-cli/spec/BuildService.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs-extra';
 import {JSZipCLI} from '../src';
 import type {BuildService} from '../src/BuildService';
+import * as glob from 'glob';
 
 describe('BuildService', () => {
   let jsZipCLI: JSZipCLI;
@@ -14,6 +15,9 @@ describe('BuildService', () => {
   };
 
   beforeEach(() => {
+    spyOn<any>(glob, 'globSync').and.callFake((params: string | string[]) =>
+      typeof params === 'string' ? [params] : params
+    );
     jsZipCLI = new JSZipCLI({
       outputEntry: 'file.zip',
       quiet: true,

--- a/packages/jszip-cli/src/BuildService.ts
+++ b/packages/jszip-cli/src/BuildService.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as progress from 'progress';
 import {FileService} from './FileService';
 import {Entry, TerminalOptions} from './interfaces';
+import * as glob from 'glob';
 
 export class BuildService {
   public compressedFilesCount: number;
@@ -42,7 +43,8 @@ export class BuildService {
 
   public add(rawEntries: string[]): BuildService {
     this.logger.info(`Adding ${rawEntries.length} entr${rawEntries.length === 1 ? 'y' : 'ies'} to ZIP file.`);
-    this.entries = rawEntries.map(rawEntry => {
+    const normalizedEntries = this.normalizePaths(rawEntries);
+    this.entries = glob.globSync(normalizedEntries).map(rawEntry => {
       const resolvedPath = path.resolve(rawEntry);
       const baseName = path.basename(rawEntry);
       return {
@@ -71,6 +73,15 @@ export class BuildService {
     }
 
     return this;
+  }
+
+  /**
+   * Note Glob patterns should always use / as a path separator, even on Windows systems,
+   * as \ is used to escape glob characters.
+   * https://github.com/isaacs/node-glob
+   */
+  private normalizePaths(rawEntries: string[]): string[] {
+    return rawEntries.map(entry => entry.replace(/\\/g, '/'));
   }
 
   private async addFile(entry: Entry, isLink = false): Promise<void> {

--- a/packages/jszip-cli/src/BuildService.ts
+++ b/packages/jszip-cli/src/BuildService.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as progress from 'progress';
 import {FileService} from './FileService';
 import {Entry, TerminalOptions} from './interfaces';
-import * as glob from 'glob';
+import {globSync} from 'glob';
 
 export class BuildService {
   public compressedFilesCount: number;
@@ -44,7 +44,7 @@ export class BuildService {
   public add(rawEntries: string[]): BuildService {
     this.logger.info(`Adding ${rawEntries.length} entr${rawEntries.length === 1 ? 'y' : 'ies'} to ZIP file.`);
     const normalizedEntries = this.normalizePaths(rawEntries);
-    this.entries = glob.globSync(normalizedEntries).map(rawEntry => {
+    this.entries = globSync(normalizedEntries).map(rawEntry => {
       const resolvedPath = path.resolve(rawEntry);
       const baseName = path.basename(rawEntry);
       return {
@@ -76,7 +76,7 @@ export class BuildService {
   }
 
   /**
-   * Note Glob patterns should always use / as a path separator, even on Windows systems,
+   * Note: glob patterns should always use / as a path separator, even on Windows systems,
    * as \ is used to escape glob characters.
    * https://github.com/isaacs/node-glob
    */

--- a/packages/mock-udp/package.json
+++ b/packages/mock-udp/package.json
@@ -24,7 +24,7 @@
     "dist": "yarn clean && yarn build",
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "1.2.1"
 }

--- a/packages/my-timezone/package.json
+++ b/packages/my-timezone/package.json
@@ -34,7 +34,7 @@
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
     "start": "ts-node src/cli.ts",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "1.2.1"
 }

--- a/packages/ntfy/package.json
+++ b/packages/ntfy/package.json
@@ -32,7 +32,7 @@
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
     "start": "ts-node src/cli.ts",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "1.2.1"
 }

--- a/packages/ntpclient/package.json
+++ b/packages/ntpclient/package.json
@@ -32,7 +32,7 @@
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
     "start": "ts-node src/cli.ts",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "1.3.1"
 }

--- a/packages/pixelflut/package.json
+++ b/packages/pixelflut/package.json
@@ -25,7 +25,7 @@
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
     "start": "ts-node src/cli.ts",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "1.4.1"
 }

--- a/packages/quick-sort/package.json
+++ b/packages/quick-sort/package.json
@@ -19,7 +19,7 @@
     "dist": "yarn clean && yarn build",
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "0.4.1"
 }

--- a/packages/scrabble-cheater/package.json
+++ b/packages/scrabble-cheater/package.json
@@ -45,7 +45,7 @@
     "generate:packagejson": "../../bin/generate-hybrid-package-json.sh",
     "postversion": "exit 0",
     "start": "ts-node-esm src/cli.ts -d",
-    "test": "ts-node-esm -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node-esm -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "type": "module",
   "version": "3.3.1"

--- a/packages/which-os/package.json
+++ b/packages/which-os/package.json
@@ -37,7 +37,7 @@
     "flatten": "node ../publish-flat/dist/cli.js -o flattened",
     "postversion": "node ../publish-flat/dist/cli-copy.js -o flattened/package.json version",
     "start": "ts-node src/cli.ts",
-    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/.bin/jasmine"
+    "test": "ts-node -P tsconfig.jasmine.json ../../node_modules/jasmine/bin/jasmine.js"
   },
   "version": "1.5.1"
 }


### PR DESCRIPTION

**situations:** 
When I use `jszip-cli add example/* -o ./example.zip` on windows, it just pack an empty file.

**changes:**
use glob to support matching * on windows