### PR TITLE
refactor: add job-level permissions to workflows

### DIFF
--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -6,14 +6,13 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  id-token: write
-  contents: write
 
 jobs:
   build_test_publish:
     name: Build, test and publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -1,7 +1,5 @@
 name: Force Release
 
-permissions:
-  contents: write
 
 on:
   workflow_dispatch:
@@ -9,6 +7,8 @@ on:
 jobs:
   force-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/git_mirror.yml
+++ b/.github/workflows/git_mirror.yml
@@ -1,7 +1,5 @@
 name: Mirror to Codeberg and GitLab
 
-permissions:
-  contents: read
 
 on:
   push:
@@ -10,6 +8,8 @@ on:
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: ffflorian/actions/git-mirror@baf8fb2e65ebe6564870f56315a09bc01ab7e0f7
         with:

--- a/.github/workflows/yarn_update.yml
+++ b/.github/workflows/yarn_update.yml
@@ -1,8 +1,5 @@
 name: Check for yarn updates
 
-permissions:
-  contents: write
-  pull-requests: write
 
 on:
   schedule:
@@ -17,6 +14,8 @@ on:
 jobs:
   yarn-update-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Update yarn
         uses: ffflorian/actions/yarn-update@baf8fb2e65ebe6564870f56315a09bc01ab7e0f7


### PR DESCRIPTION
Remove global permissions blocks and add job-specific permissions to all workflows.

Each job now includes appropriate permissions based on its operations:
- Standard jobs: contents: read
- Publishing jobs: id-token: write, contents: write
- Security jobs: security-events: write, packages: read, actions: read

Follows GitHub Security Hardening best practices:
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs