### PR TITLE
fix(electron-info): replace date-fns with native Date API

### DIFF
--- a/packages/electron-info/package.json
+++ b/packages/electron-info/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "chalk": "5.6.2",
     "commander": "15.0.0",
-    "date-fns": "4.4.0",
     "logdown": "3.3.1",
     "semver": "7.8.1",
     "table": "6.9.0"

--- a/packages/electron-info/src/FileService.test.ts
+++ b/packages/electron-info/src/FileService.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, test} from 'vitest';
+
+import {isWithinLastDay} from './FileService.js';
+
+describe('isWithinLastDay', () => {
+  test('returns true when date is just after the same time yesterday', () => {
+    const now = new Date('2026-01-15T12:00:00.000Z');
+    const justAfter = new Date('2026-01-14T12:00:00.001Z');
+    expect(isWithinLastDay(justAfter, now)).toBe(true);
+  });
+
+  test('returns false when date is exactly the same time yesterday', () => {
+    const now = new Date('2026-01-15T12:00:00.000Z');
+    const exactlyYesterday = new Date('2026-01-14T12:00:00.000Z');
+    expect(isWithinLastDay(exactlyYesterday, now)).toBe(false);
+  });
+
+  test('returns false when date is before yesterday', () => {
+    const now = new Date('2026-01-15T12:00:00.000Z');
+    const twoDaysAgo = new Date('2026-01-13T12:00:00.000Z');
+    expect(isWithinLastDay(twoDaysAgo, now)).toBe(false);
+  });
+
+  test('returns true when date equals now', () => {
+    const now = new Date('2026-01-15T12:00:00.000Z');
+    expect(isWithinLastDay(now, now)).toBe(true);
+  });
+});

--- a/packages/electron-info/src/FileService.ts
+++ b/packages/electron-info/src/FileService.ts
@@ -88,9 +88,7 @@ export class FileService {
     const {mtime: fileModifiedDate} = await fs.stat(fileName);
     this.logger.log(`File "${fileName}" is from "${fileModifiedDate.toString()}"`);
 
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    return fileModifiedDate > yesterday;
+    return isWithinLastDay(fileModifiedDate);
   }
 
   private async isPathReadable(filePath: string): Promise<boolean> {
@@ -114,4 +112,10 @@ export class FileService {
 
     return releases;
   }
+}
+
+export function isWithinLastDay(date: Date, now = new Date()): boolean {
+  const yesterday = new Date(now);
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+  return date > yesterday;
 }

--- a/packages/electron-info/src/FileService.ts
+++ b/packages/electron-info/src/FileService.ts
@@ -1,4 +1,3 @@
-import {isAfter as isAfterDate, sub as subtractDate} from 'date-fns';
 import logdown from 'logdown';
 import {promises as fs, constants as fsConstants} from 'node:fs';
 import os from 'node:os';
@@ -89,8 +88,9 @@ export class FileService {
     const {mtime: fileModifiedDate} = await fs.stat(fileName);
     this.logger.log(`File "${fileName}" is from "${fileModifiedDate.toString()}"`);
 
-    const yesterday = subtractDate(new Date(), {days: 1});
-    return isAfterDate(fileModifiedDate, yesterday);
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    return fileModifiedDate > yesterday;
   }
 
   private async isPathReadable(filePath: string): Promise<boolean> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4656,13 +4656,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:4.4.0":
-  version: 4.4.0
-  resolution: "date-fns@npm:4.4.0"
-  checksum: 10c0/988f0a13db183f5dfc85c36bbb6847a9c135a9225888bbea4005876ec15539a8613c21a07370a4e7ea543918d5a1cafb423c528b42cdbbde5fdfddb178126b21
-  languageName: node
-  linkType: hard
-
 "debug@npm:4, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
@@ -4924,7 +4917,6 @@ __metadata:
     "@types/semver": "npm:7.7.1"
     chalk: "npm:5.6.2"
     commander: "npm:15.0.0"
-    date-fns: "npm:4.4.0"
     http-status-codes: "npm:2.3.0"
     logdown: "npm:3.3.1"
     nock: "npm:14.0.15"


### PR DESCRIPTION
## Summary

- Removes the `date-fns` dependency from `electron-info`
- Replaces two functions (`sub`, `isAfter`) used for a 24-hour cache freshness check with equivalent native `Date` methods
- No behaviour change

## Test plan

- [x] `yarn workspace electron-info build` passes
- [x] `yarn workspace electron-info test` passes (7 tests, 5 skipped)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAnap4n45uAaEbftG8LpW8)_