### PR TITLE
ci(deps): block only next major in dependabot ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,11 +20,11 @@ updates:
           - protobufjs*
     ignore:
       - dependency-name: '@types/node'
-        versions:
-          - '> 26'
+        update-types:
+          - version-update:semver-major
       - dependency-name: '@types/express'
-        versions:
-          - '> 4'
+        update-types:
+          - version-update:semver-major
     open-pull-requests-limit: 99
     package-ecosystem: npm
     schedule:


### PR DESCRIPTION
Replace 'versions: [> N]' ranges with update-types semver-major so
minor/patch updates continue to flow while only the next major is held.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JGRH76KuDJTCfkf4QEUroR